### PR TITLE
Refactor: Remove hardcoded DB credentials and prompt you

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,11 +1,35 @@
 // server.js (root)
 const express = require('express');
 const path = require('path');
-const getDatabaseManager = require('./src/models/database');
+const readline = require('readline');
+const DatabaseManager = require('./src/models/database');
 const ExpenseManagerServerController = require('./src/controllers/main-controller');
 
+// Function to prompt user for database connection details
+async function promptForDbDetails() {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+
+    return new Promise((resolve) => {
+        rl.question('Please enter your PostgreSQL connection string: ', (connectionString) => {
+            rl.close();
+            resolve(connectionString);
+        });
+    });
+}
+
 async function main() {
-    const dbManager = getDatabaseManager();
+    const connectionString = await promptForDbDetails();
+
+    if (!connectionString || connectionString.trim() === '') {
+        console.error('PostgreSQL connection string is required. Exiting.');
+        process.exit(1);
+    }
+
+    const SCHEMA_PATH = path.resolve(__dirname, 'src', 'models', 'schema.sql');
+    const dbManager = new DatabaseManager(connectionString, SCHEMA_PATH);
     const PORT = 3000;
 
     const app = express();

--- a/src/models/database.js
+++ b/src/models/database.js
@@ -10,9 +10,10 @@ class DatabaseManager {
      * @param {string} schemaPath - The path to the SQL schema file.
      */
     constructor(connectionString, schemaPath) {
-        // Default PostgreSQL connection string
-        // IMPORTANT: Replace with your actual connection details
-        this.connectionString = connectionString || 'postgresql://user:password@localhost:5432/expense_manager_db';
+        if (!connectionString) {
+            throw new Error('Database connection string is required.');
+        }
+        this.connectionString = connectionString;
         this.schemaPath = schemaPath;
         this.pool = null; // pg Pool instance
     }
@@ -146,14 +147,4 @@ class DatabaseManager {
     }
 }
 
-/**
- * Creates and returns a new instance of the DatabaseManager.
- * @returns {DatabaseManager} A new DatabaseManager instance.
- */
-function getDatabaseManager() {
-    // SCHEMA_PATH is still needed, connection string will use default from constructor
-    const SCHEMA_PATH = path.resolve(__dirname, './schema.sql');
-    return new DatabaseManager(null, SCHEMA_PATH); // Pass null for connectionString to use default
-}
-
-module.exports = getDatabaseManager;
+module.exports = DatabaseManager;


### PR DESCRIPTION
This removes the hardcoded PostgreSQL connection string from the DatabaseManager. The application will now prompt you via the command line to enter your PostgreSQL connection string upon startup.

This change allows you to connect to any PostgreSQL database, including Supabase instances, by providing the appropriate connection URI.

Key changes:
- Modified `src/models/database.js`:
    - `DatabaseManager` constructor no longer has a default connection string and requires it as an argument.
    - Removed `getDatabaseManager` function; `DatabaseManager` class is now exported directly.
- Modified `server.js`:
    - Added `readline` to prompt you for the PostgreSQL connection string.
    - Initializes `DatabaseManager` with the string you provided.
    - Exits if no connection string is provided.