### PR TITLE
feat: Filter expenses by month and enhance analytics tab

### DIFF
--- a/src/controllers/main-controller.js
+++ b/src/controllers/main-controller.js
@@ -212,7 +212,8 @@ class ExpenseManagerServerController {
             return res.status(503).json({ error: 'Database not connected. Please connect to the database first.' });
         }
         try {
-            const expenses = await this.expenseRepository.getAllExpenses();
+            // Pass true to filter by current month when DB is connected
+            const expenses = await this.expenseRepository.getAllExpenses(true); // New call
             res.json(expenses);
         } catch (err) {
             console.error('Error fetching expenses:', err.message);


### PR DESCRIPTION
- Main expenses view now displays expenses for the current month by default when the database is connected.
- Analytics tab now lists individual filtered expenses with edit and delete functionality, alongside the category breakdown.

Detailed changes:
- Modified `ExpenseRepository.getAllExpenses` to filter by the current month.
- Updated `main-controller.js` to use this filter for the main expenses view.
- Modified `ExpenseRepository.getAnalyticsData` to return detailed filtered expense records.
- Updated `analytics-controller.js` (`AnalyticsManager`) to display these filtered expenses and handle callbacks for their actions.
- Made `UIManager.renderExpenses` more generic to be reusable by both the main expenses tab and the analytics tab, including conditional rendering of action buttons.
- Updated `app-controller.js` to integrate these changes, manage callbacks, and ensure context-aware data refreshing after CRUD operations on expenses from either view.