### PR TITLE
Fix: Increase request payload size limit

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ async function main() {
 
     // Then Middleware setup
     const bodyParser = require('body-parser'); 
-    app.use(bodyParser.json());
+    app.use(bodyParser.json({ limit: '50mb' }));
     app.use(express.static(path.join(__dirname, 'src'))); 
 
     // Initialize and use routes from the controller FIRST


### PR DESCRIPTION
I've increased the request payload size limit for JSON bodies to 50mb in `server.js` by updating the `bodyParser.json()` middleware. This is to prevent "PayloadTooLargeError" when you import large datasets, particularly large CSV files.

You will need to manually verify this post-deployment to confirm the fix resolves the issue for very large file imports.